### PR TITLE
Fix over pixelized images in widget

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/widget/AppWidgetUpdateTask.kt
@@ -179,7 +179,6 @@ private fun Bitmap.scale(widgetWidth: Int, widgetHeight: Int): Bitmap? {
             widgetWidth == 0 || widgetHeight == 0) {
         return null
     }
-    val widgetIsLandscape = widgetWidth >= widgetHeight
     // Crop image first here for highest quality
     var croppedImage: Bitmap
     val largestDimension = max(widgetWidth, widgetHeight)


### PR DESCRIPTION
We are using cropCenter in layout. 
But cropping happens on a low quality image, this produces pixlized images when widget is landscape and image is portrait for example. 
So, do an initial square cropping before sending image to widget