### PR TITLE
Fix Provider.supportsNextArtwork being reset to false using Tasker

### DIFF
--- a/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerActionReceiver.kt
+++ b/main/src/main/java/com/google/android/apps/muzei/tasker/TaskerActionReceiver.kt
@@ -42,14 +42,18 @@ class TaskerActionReceiver : BroadcastReceiver() {
             when (val selectedAction = TaskerAction.fromBundle(
                     intent.getBundleExtra(EXTRA_BUNDLE))) {
                 is SelectProviderAction -> {
-                    val authority = selectedAction.authority
-                    if (context.packageManager.resolveContentProvider(authority, 0) != null) {
+                    val newAuthority = selectedAction.authority
+                    if (context.packageManager.resolveContentProvider(newAuthority, 0) != null) {
                         Firebase.analytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
-                            param(FirebaseAnalytics.Param.ITEM_LIST_ID, authority)
+                            param(FirebaseAnalytics.Param.ITEM_LIST_ID, newAuthority)
                             param(FirebaseAnalytics.Param.ITEM_LIST_NAME, "providers")
                             param(FirebaseAnalytics.Param.CONTENT_TYPE, "tasker")
                         }
-                        ProviderManager.select(context, authority)
+
+                        val existingAuthority = ProviderManager.getInstance(context).value?.authority
+                        if (existingAuthority != newAuthority) {
+                            ProviderManager.select(context, newAuthority)
+                        }
                     }
                 }
                 is NextArtworkAction -> {


### PR DESCRIPTION
When a provider is selected through the Tasker select provider action, it normally triggers the `ProviderChangedWorker` to check whether the provider supports next artwork.

However if the new provider authority is identical to the current provider, the `ProviderChangedWorker` is not triggered, but `                            ProviderManager.select(context, authority)` is still run by the `TaskerActionReceiver` which resets `supportsNextArtwork` to `false` and is never updated (unless you switch to another provider and back). 

This then causes the widget to never show the next artwork button.

