### PR TITLE
Specify PendingIntent mutability in getArtworkInfo() within MuzeiArtProvider

### DIFF
--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.kt
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.kt
@@ -642,7 +642,12 @@ public abstract class MuzeiArtProvider : ContentProvider(), ProviderClient {
     public open fun getArtworkInfo(artwork: Artwork): PendingIntent? {
         if (artwork.webUri != null && context != null) {
             val intent = Intent(Intent.ACTION_VIEW, artwork.webUri)
-            return PendingIntent.getActivity(context, 0, intent, 0)
+            return PendingIntent.getActivity(
+                context, 
+                0, 
+                intent, 
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            )
         }
         return null
     }

--- a/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.kt
+++ b/muzei-api/src/main/java/com/google/android/apps/muzei/api/provider/MuzeiArtProvider.kt
@@ -639,15 +639,11 @@ public abstract class MuzeiArtProvider : ContentProvider(), ProviderClient {
      * @return A [PendingIntent] generally constructed with
      * [PendingIntent.getActivity].
      */
+    @SuppressLint("InlinedApi")
     public open fun getArtworkInfo(artwork: Artwork): PendingIntent? {
         if (artwork.webUri != null && context != null) {
             val intent = Intent(Intent.ACTION_VIEW, artwork.webUri)
-            return PendingIntent.getActivity(
-                context, 
-                0, 
-                intent, 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
-            )
+            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         }
         return null
     }


### PR DESCRIPTION
Without this, Muzei plugins that target API 31 and when run on Android 12.0+ cannot view artwork information, instead returning an `IllegalArgumentException` described [here](https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent)
An API level check is included to maintain compatability with Android versions lower than M