### PR TITLE
Switch API endpoint to muzei.co

### DIFF
--- a/source-featured-art/src/main/java/com/google/android/apps/muzei/featuredart/FeaturedArtWorker.kt
+++ b/source-featured-art/src/main/java/com/google/android/apps/muzei/featuredart/FeaturedArtWorker.kt
@@ -59,7 +59,7 @@ class FeaturedArtWorker(
         private const val TAG = "FeaturedArtWorker"
         private const val PREF_NEXT_UPDATE_MILLIS = "next_update_millis"
 
-        private const val QUERY_URL = "https://muzeiapi.appspot.com/featured?cachebust=1"
+        private const val QUERY_URL = "https://muzei.co/featured?cachebust=1"
 
         private const val KEY_IMAGE_URI = "imageUri"
         private const val KEY_TITLE = "title"


### PR DESCRIPTION
Should behave exactly the same, but allows us to swap GCP projects if needed.